### PR TITLE
Reduced the field of description of the package; fixed a bug in citat…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,15 +2,17 @@ Package: BayesVarSel
 Type: Package
 Title: Bayes Factors, Model Choice and Variable Selection in Linear
         Models
-Version: 2.2.4
-Date: 2023-02-17
+Version: 2.2.5
+Date: 2023-03-07
 Authors@R: c(
-    person("Gonzalo", "Garcia-Donato",    email = "gonzalo.garciadonato@uclm.es",    role = c("aut")),
+    person("Gonzalo", "Garcia-Donato",    email = "gonzalo.garciadonato@uclm.es",    role = c("aut", "cre")),
     person("Anabel", "Forte",             email = "anabel.forte@uv.es",   role = c("aut", "cre")),
     person("Carlos", "Vergara-Hernández", email = "carlos.vergara@uv.es", role = c("ctb"))
     )
-Maintainer: Anabel Forte <anabel.forte@uv.es>
-Description: Conceived to calculate Bayes factors in Linear models and then to provide a formal Bayesian answer to testing and variable selection problems. From a theoretical side, the emphasis in this package is placed on the prior distributions and it allows a wide range of them: Jeffreys (1961); Zellner and Siow(1980)<DOI:10.1007/bf02888369>; Zellner and Siow(1984); Zellner (1986)<DOI:10.2307/2233941>; Fernandez et al. (2001)<DOI:10.1016/s0304-4076(00)00076-2>; Liang et al. (2008)<DOI:10.1198/016214507000001337>  and Bayarri et al. (2012)<DOI:10.1214/12-aos1013>. The interaction with the package is through a friendly interface that syntactically mimics the well-known lm() command of R. The resulting objects can be easily explored providing the user very valuable information (like marginal, joint and conditional inclusion probabilities of potential variables; the highest posterior probability model, HPM; the median probability model, MPM) about the structure of the true -data generating- model. Additionally, this package incorporates abilities to handle problems with a large number of potential explanatory variables through parallel and heuristic versions of the main commands, Garcia-Donato and Martinez-Beneito (2013)<DOI:10.1080/01621459.2012.742443>. It also allows problems with p>n and p>>n and also incorporates routines to handle problems with variable selection with factors.
+Maintainer: Gonzalo Garcia-Donato <gonzalo.garciadonato@uclm.es>
+Description: Bayes factors and posterior probabilities in Linear models, 
+    aimed at provide a formal Bayesian answer to testing and variable 
+    selection problems. 
 Acknowledgements: since version 1.9.0 BayesVarSel uses the non-exported function get_rdX from package lmerTest (distributed under GPL-2, GPL-3) and authored by Alexandra Kuznetsova, Per Bruun Brockhoff and Rune Haubo Bojesen Christensen.
 Encoding: UTF-8
 LazyData: TRUE

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,5 +1,4 @@
-
-bitentry(
+bibentry(
     bibtype     = "Article",
     title       = "Bayesian Testing, Variable Selection and Model Averaging in Linear Models using {R} with {BayesVarSel}",
     author      = c(person("Gonzalo Garcia-Donato"), person("Anabel Forte")),


### PR DESCRIPTION
…ion (it was written bitentry instead of bibentry) and changed the mantainer name (to me)